### PR TITLE
Bump to 0.24.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="0.24" %}
+{% set version="0.24.1" %}
 
 package:
   name: cython
@@ -7,7 +7,7 @@ package:
 source:
   fn: Cython-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/C/Cython/Cython-{{ version }}.tar.gz
-  md5: 14fbc970f4a856845e633cbc09e61048
+  md5: 890b494a12951f1d6228c416a5789554
 
 build:
   number: 0
@@ -46,3 +46,4 @@ extra:
   recipe-maintainers:
     - jakirkham
     - msarahan
+    - ocefpaf


### PR DESCRIPTION
```
0.24.1 (2016-07-15)
===================

Bugs fixed
----------

* IPython cell magic was lacking a good way to enable Python 3 code semantics.
  It can now be used as "%%cython -3".

* Follow a recent change in `PEP 492 <https://www.python.org/dev/peps/pep-0498/>`_
  and CPython 3.5.2 that now requires the ``__aiter__()`` method of asynchronous
  iterators to be a simple ``def`` method instead of an ``async def`` method.

* Coroutines and generators were lacking the ``__module__`` special attribute.

* C++ ``std::complex`` values failed to auto-convert from and to Python complex
  objects.

* Namespaced C++ types could not be used as memory view types due to lack of
  name mangling.  Patch by Ivan Smirnov.

* Assignments between identical C++ types that were declared with differently
  typedefed template types could fail.

* Rebuilds could fail to evaluate dependency timestamps in C++ mode.
  Patch by Ian Henriksen.

* Macros defined in the ``distutils`` compiler option do not require values
  anymore.  Patch by Ian Henriksen.

* Minor fixes for MSVC, Cygwin and PyPy.
```