### PR TITLE
Release 0.27.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="0.27.2" %}
+{% set version="0.27.3" %}
 
 package:
   name: cython
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/C/Cython/Cython-{{ version }}.tar.gz
-  sha256: 265dacf64ed8c0819f4be9355c39beaa13dc2ad2f85237a2c4e478f5ce644b48
+  sha256: 6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64
 
 build:
   number: 0


### PR DESCRIPTION
```rst
0.27.3 (2017-11-03)
===================

Bugs fixed
----------

* String forward references to extension types like ``@cython.locals(x="ExtType")``
  failed to find the named type.  (Github issue #1962)

* NumPy slicing generated incorrect results when compiled with Pythran.
  Original patch by Serge Guelton (Github issue #1946).

* Fix "undefined reference" linker error for generators on Windows in Py3.3-3.5.
  (Github issue #1968)

* Adapt to recent C-API change of ``PyThreadState`` in CPython 3.7.

* Fix signature of ``PyWeakref_GetObject()`` API declaration.
  Patch by Jeroen Demeyer (Github issue #1975).
```