### PR TITLE
Temporarily add Python 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,27 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
+  build__CONDA_PY_34:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONDA_PY: "34"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./ci_support/fast_finish_ci_pr_build.sh
+            ./ci_support/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          name: Print conda-build environment variables
+          command: |
+            echo "CONDA_PY=${CONDA_PY}"
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./ci_support/run_docker_build.sh
   build__CONDA_PY_35:
     working_directory: ~/test
     machine: true
@@ -70,5 +91,6 @@ workflows:
   build_and_test:
     jobs:
       - build__CONDA_PY_27
+      - build__CONDA_PY_34
       - build__CONDA_PY_35
       - build__CONDA_PY_36

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
     
     - CONDA_PY=27
+    - CONDA_PY=34
     - CONDA_PY=35
     - CONDA_PY=36
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,14 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
+      CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 


### PR DESCRIPTION
Adds Python 3.4 to the CI matrices temporarily for a one off build of Cython for Python 3.4. Can be dropped immediately afterwards.