### PR TITLE
Re-enable compilation test; try out macOS+Py3.8 multiprocessing failure

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - python
 
 test:
+  requires:
+    - {{ compiler('c') }}
   commands:
     - cython --version
   files:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -21,21 +21,19 @@ print('sys.version: %r' % sys.version)
 print('PATH: %r' % os.environ['PATH'])
 print('CWD: %r' % os.getcwd())
 
-from distutils.spawn import find_executable
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 
-if find_executable('gcc'):
-    sys.argv[1:] = ['build_ext', '--inplace']
-    setup(name='fib',
-          cmdclass={'build_ext': build_ext},
-          ext_modules=[Extension("fib", ["fib.pyx"])])
+sys.argv[1:] = ['build_ext', '--inplace']
+setup(name='fib',
+      cmdclass={'build_ext': build_ext},
+      ext_modules=[Extension("fib", ["fib.pyx"])])
 
-    try:
-        import fib
-        assert fib.fib(10) == 55
-    except ImportError:
-        cmd = [sys.executable, '-c', 'import fib; print(fib.fib(10))']
-        out = subprocess.check_output(cmd)
-        assert out.decode('utf-8').strip() == '55'
+try:
+    import fib
+    assert fib.fib(10) == 55
+except ImportError:
+    cmd = [sys.executable, '-c', 'import fib; print(fib.fib(10))']
+    out = subprocess.check_output(cmd)
+    assert out.decode('utf-8').strip() == '55'


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
I'll try to add a test for https://github.com/conda-forge/pydantic-feedstock/pull/31#issuecomment-561378096, i.e., testing whether `cythonize` fails on macOS + Py3.8 for `nthreads>0`.

<!--
Please add any other relevant info below:
-->
The compilation test was guarded by `if find_executable('gcc'):` which means it has never been run since the compiler switch. Re-enabling this here too.