### PR TITLE
cython 0.29.30

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.29.29" %}
+{% set version = "0.29.30" %}
 
 package:
   name: cython
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/C/Cython/Cython-{{ version }}.tar.gz
-  sha256: ce70dbbfbe374ee0d02fd16c26d5e512424fd0ab2927150a3f99d108bd0d8a20
+  sha256: 2235b62da8fe6fa8b99422c8e583f2fb95e143867d337b5c75e4b9a1a865f9e3
 
 build:
   number: 0


### PR DESCRIPTION
Emergency bugfix release after 0.29.29, see [here](https://github.com/cython/cython/commit/a6f04ef2430fb4e7383a068cd1ae9a115d7a78df)