### PR TITLE
Add setuptools as a runtime dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ requirements:
   run:
     - python >={{ python_min }}  # [use_noarch]
     - python                     # [not use_noarch]
+    - setuptools
 
 test:
   requires:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I was using this package and ran into this error:

```
  File "/home/mmh/micromamba/envs/python313/lib/python3.13/site-packages/Cython/Build/Dependencies.py", line 1010, in cythonize
    module_list, module_metadata = create_extension_list(
                                   ~~~~~~~~~~~~~~~~~~~~~^
        module_list,
        ^^^^^^^^^^^^
    ...<4 lines>...
        language=language,
        ^^^^^^^^^^^^^^^^^^
        aliases=aliases)
        ^^^^^^^^^^^^^^^^
  File "/home/mmh/micromamba/envs/python313/lib/python3.13/site-packages/Cython/Build/Dependencies.py", line 784, in create_extension_list
    from distutils.extension import Extension
ModuleNotFoundError: No module named 'distutils'
```

And investigating had me stumble into https://github.com/cython/cython/issues/5751

I wasn't sure if we want to pin a lower bound or not, but setuptools backwards compitblity stuff for distutils is needed. 